### PR TITLE
consistency with mongoose' models

### DIFF
--- a/lib/mongoose-email-address-manager.js
+++ b/lib/mongoose-email-address-manager.js
@@ -45,21 +45,21 @@ var emailAddressManagerPlugin = function(schema, options){
     
     schema.statics.findOneByEmail = function(email){
         arguments[0] = {'email_addresses.email_address': email};
-        this.findOne.apply(this, arguments);
+        return this.findOne.apply(this, arguments);
     };
 
     schema.statics.findByEmail = function(email){
         arguments[0] = {'email_addresses.email_address': email};
-        this.find.apply(this, arguments);
+        return this.find.apply(this, arguments);
     };
 
     schema.statics.findByEmailVerificationCode = function(code){
         arguments[0] = {'email_addresses.verification.code': code};
-        this.findOne.apply(this, arguments);
+        return this.findOne.apply(this, arguments);
     };
 
     schema.statics.emailExists = function(email, callback){
-        this.findOneByEmail(email, function(err, doc){
+        return this.findOneByEmail(email, function(err, doc){
             callback(err, !!doc);
         });
     };


### PR DESCRIPTION
Static methods do not pass through the return values of the original mongoose query methods. Thus for example the usage of [Promise styled syntax](http://mongoosejs.com/docs/api.html#query_Query-exec) becomes impossible...
